### PR TITLE
Added config option run_on_create 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ results.html
 pkg
 html
 *.gem
-.spoonrc #used for testing
+.spoonrc
+spoonrc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docker-spoon (0.6.0)
+    docker-spoon (0.7.0)
       docker-api (~> 1.11)
       methadone (~> 1.4.0)
       rainbow (~> 2.0)
@@ -24,11 +24,11 @@ GEM
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.1)
     diff-lcs (1.2.5)
-    docker-api (1.13.3)
+    docker-api (1.13.6)
       archive-tar-minitar
       excon (>= 0.38.0)
       json
-    excon (0.39.6)
+    excon (0.40.0)
     ffi (1.9.5)
     gherkin (2.12.2)
       multi_json (~> 1.3)

--- a/README.md
+++ b/README.md
@@ -198,6 +198,19 @@ Example:
 options[:add_authorized_keys] = "id_rsa.pub"
 ```
 
+  `run_on_create` - This is a list of commands to run on a spoon container
+  once it has been started. This allows you to quickly and automatically
+  modify a spoon environment upon creation to meet any needs you have
+  which aren't baked into the Docker image. This is a config-only
+	option, there is no command line for this. Commands are run one at a
+	time over ssh - enabling :add_authorized_keys makes this option more
+	tolerable.
+
+Example:
+```
+options[:run_on_create] = [ "sudo apt-get -y install emacs" ]
+```
+
 #### Container expectations
 
 When building an image for use with docker-spoon you must build an


### PR DESCRIPTION
This allows commands to be run on container creation based on a config option. This is intended to allow easy modification of a container on startup vs. having to rebuild the container - handy for individual personalization or quick fixes pending a proper fix in a container build. Addresses issue #11 
