### PR TITLE
Added ssh port forward support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docker-spoon (0.6.0)
+    docker-spoon (0.7.0)
       docker-api (~> 1.11)
       methadone (~> 1.4.0)
       rainbow (~> 2.0)
@@ -24,11 +24,11 @@ GEM
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.1)
     diff-lcs (1.2.5)
-    docker-api (1.13.3)
+    docker-api (1.13.6)
       archive-tar-minitar
       excon (>= 0.38.0)
       json
-    excon (0.39.6)
+    excon (0.40.0)
     ffi (1.9.5)
     gherkin (2.12.2)
       multi_json (~> 1.3)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ in.
 - `--image`, The image name to use when starting a spoon container.
 - `--prefix`, The prefix to use for creating, listing & destroying
   containers.
+- `--portforwards`, This is a space separated list of ports to forward
+  over ssh. The format is either `sourceport:destport` or  just `sourceport`
+  in which case the same port will be used for source & destination.
+	Multiple port forwards may be separated by spaces, for exampe
+	`--portforwards '8080 8081:9090'`
 
 ### List
 

--- a/lib/spoon.rb
+++ b/lib/spoon.rb
@@ -62,6 +62,7 @@ module Spoon
   options[:config] = "#{ENV['HOME']}/.spoonrc"
   on("-c FILE", "--config", "Config file to use for spoon options")
   on("--debug", "Enable debug")
+  on("-P PORT", "--portforwards", "Forward PORT over ssh (must be > 1023)")
 
 
   arg(:instance, :optional, "Spoon instance to connect to")
@@ -224,14 +225,26 @@ module Spoon
     get_container(name)
   end
 
+  def self.get_port_forwards(forwards = "")
+    if options[:portforwards]
+      options[:portforwards].split.each do |port|
+        (lport,rport) = port.split(':')
+        forwards << "-L #{lport}:127.0.0.1:#{rport || lport} "
+      end
+    end
+    return forwards
+  end
+
   def self.instance_ssh(name, command='')
     container = get_container(name)
+    forwards = get_port_forwards
+    D "Got forwards: #{forwards}"
     host = URI.parse(options[:url]).host
     if container
       ssh_command = "\"#{command}\"" if not command.empty?
       ssh_port = get_port('22', container)
       puts "Waiting for #{name}:#{ssh_port}..." until host_available?(host, ssh_port)
-      exec("ssh -t -o StrictHostKeyChecking=no -p #{ssh_port} pairing@#{host} #{ssh_command}")
+      exec("ssh -t -o StrictHostKeyChecking=no -p #{ssh_port} #{forwards} pairing@#{host} #{ssh_command}")
     else
       puts "No container named: #{container.inspect}"
     end


### PR DESCRIPTION
This allows forwarding of ports over ssh which you either do not want to expose publicly via Docker or that aren't exposed in the container, thus cannot be made public. Useful for quick access to ports inside a container without modifying the container (just requires a disconnect / reconnect via spoon). 
